### PR TITLE
Reduce z-index, so it doesnt overlap navbar

### DIFF
--- a/packages/@snippetors/vuepress-plugin-code-copy/lib/components/CodeCopy.vue
+++ b/packages/@snippetors/vuepress-plugin-code-copy/lib/components/CodeCopy.vue
@@ -125,7 +125,7 @@ svg {
   right: 7.5px;
   opacity: 0.75;
   cursor: pointer;
-  z-index: 19;
+  z-index: 1;
 }
 
 svg.hover {

--- a/packages/@snippetors/vuepress-plugin-code-copy/lib/components/CodeCopy.vue
+++ b/packages/@snippetors/vuepress-plugin-code-copy/lib/components/CodeCopy.vue
@@ -125,7 +125,7 @@ svg {
   right: 7.5px;
   opacity: 0.75;
   cursor: pointer;
-  z-index: 9999;
+  z-index: 19;
 }
 
 svg.hover {


### PR DESCRIPTION
# 9999 z-index:

![](https://media.discordapp.net/attachments/557565999755558912/944973757154459668/unknown.png)
---

# 19 z-index:
![](https://media.discordapp.net/attachments/557565999755558912/944972813842935858/unknown.png)

I apologise for not speaking your language.